### PR TITLE
Replace apache commons-lang with own methods

### DIFF
--- a/src/main/java/roryslibrary/util/ItemName.java
+++ b/src/main/java/roryslibrary/util/ItemName.java
@@ -1,6 +1,5 @@
 package roryslibrary.util;
 
-import org.apache.commons.lang.WordUtils;
 import org.bukkit.Material;
 
 public enum ItemName {
@@ -364,19 +363,30 @@ public enum ItemName {
 		}
 		return null;
 	}
-	
+
 	public String toString() {
 		return name;
 	}
-	
+
 	//Returns the item name with the first letter uppercased (Example: pressure plate -> Pressure plate)
 	public String firstUpperCased() {
 		return Character.toUpperCase(name.charAt(0)) + name.substring(1);
 	}
-	
+
 	//Returns the item name with all the words with the first letter uppercased (Example: pressure plate -> Pressure Plate)
 	public String firstAllUpperCased() {
-		return WordUtils.capitalizeFully(name);
+		StringBuilder result    = new StringBuilder();
+		char[]        charArray = name.toLowerCase().toCharArray();
+		for (int i = 0; i < charArray.length; i++) {
+			Character previous = i > 0 ? charArray[i - 1] : null;
+			char      c        = charArray[i];
+			if (previous == null || previous == ' ')
+			{
+				c = Character.toUpperCase(c);
+			}
+			result.append(c);
+		}
+		return result.toString();
 	}
 	
 	//Returns the item name with all the letters uppercased (Example: pressure plate -> PRESSURE PLATE)

--- a/src/main/java/roryslibrary/util/MessagingUtil.java
+++ b/src/main/java/roryslibrary/util/MessagingUtil.java
@@ -1,9 +1,9 @@
 package roryslibrary.util;
 
+import java.io.StringWriter;
 import lombok.Getter;
 import lombok.Setter;
 import net.md_5.bungee.api.ChatColor;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -345,7 +345,7 @@ public abstract class MessagingUtil {
 	}
 	
 	public static String format(String msg, String... placeholders) {
-		msg = StringEscapeUtils.unescapeJava(ChatColor.translateAlternateColorCodes('&', replacePlaceholders(msg, placeholders)));
+		msg = unescapeJava(ChatColor.translateAlternateColorCodes('&', replacePlaceholders(msg, placeholders)));
 		
 		if (supportsHex) {
 			Matcher matcher = HEX_PATTERN.matcher(msg);
@@ -358,7 +358,99 @@ public abstract class MessagingUtil {
 		
 		return msg;
 	}
-	
+
+	/**
+	 * <p>Unescapes any Java literals found in the {@code String}.
+	 *
+	 * <p>For example, it will turn a sequence of {@code '\'} and
+	 * {@code 'n'} into a newline character, unless the {@code '\'}
+	 * is preceded by another {@code '\'}.</p>
+	 *
+	 * <p>Code is copied from apache commons-lang2 StringEscapeUtils</p>
+	 *
+	 * @param str the {@code String} to unescape, may be null
+	 * @return unescaped result
+	 */
+	private static String unescapeJava(String str) {
+		StringWriter out = new StringWriter(str.length());
+		int sz = str.length();
+		StringBuilder unicode = new StringBuilder(4);
+		boolean hadSlash = false;
+		boolean inUnicode = false;
+		for (int i = 0; i < sz; i++) {
+			char ch = str.charAt(i);
+			if (inUnicode) {
+				// if in unicode, then we're reading unicode
+				// values in somehow
+				unicode.append(ch);
+				if (unicode.length() == 4) {
+					// unicode now contains the four hex digits
+					// which represents our unicode character
+					try {
+						int value = Integer.parseInt(unicode.toString(), 16);
+						out.write((char) value);
+						unicode.setLength(0);
+						inUnicode = false;
+						hadSlash = false;
+					} catch (NumberFormatException nfe) {
+						throw new RuntimeException("Unable to parse unicode value: " + unicode, nfe);
+					}
+				}
+				continue;
+			}
+			if (hadSlash) {
+				// handle an escaped value
+				hadSlash = false;
+				switch (ch) {
+					case '\\':
+						out.write('\\');
+						break;
+					case '\'':
+						out.write('\'');
+						break;
+					case '\"':
+						out.write('"');
+						break;
+					case 'r':
+						out.write('\r');
+						break;
+					case 'f':
+						out.write('\f');
+						break;
+					case 't':
+						out.write('\t');
+						break;
+					case 'n':
+						out.write('\n');
+						break;
+					case 'b':
+						out.write('\b');
+						break;
+					case 'u':
+					{
+						// uh-oh, we're in unicode country....
+						inUnicode = true;
+						break;
+					}
+					default :
+						out.write(ch);
+						break;
+				}
+				continue;
+			} else if (ch == '\\') {
+				hadSlash = true;
+				continue;
+			}
+			out.write(ch);
+		}
+		if (hadSlash) {
+			// then we're in the weird case of a \ at the end of the
+			// string, let's output it anyway.
+			out.write('\\');
+		}
+		return out.toString();
+	}
+
 	public static List<String> format(List<String> msg, String... placeholders) {
 		for (int i = msg.size() - 1; i >= 0; i--)
 			msg.add(i, format(msg.remove(i), placeholders));


### PR DESCRIPTION
Newer Minecraft versions do not contain commons-lang library anymore. Replacing the two used methods makes sure this project still works without the need to include the library yourself.